### PR TITLE
add-surrealdb-persistent-storage

### DIFF
--- a/src-tauri/src/database/connection/mod.rs
+++ b/src-tauri/src/database/connection/mod.rs
@@ -1,0 +1,1 @@
+pub mod surreal;

--- a/src-tauri/src/database/connection/surreal.rs
+++ b/src-tauri/src/database/connection/surreal.rs
@@ -1,0 +1,21 @@
+use std::sync::LazyLock;
+use surrealdb::engine::remote::ws::{Client, Ws};
+use surrealdb::opt::auth::Root;
+use surrealdb::Surreal;
+
+pub static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
+
+pub async fn database_connection() -> surrealdb::Result<()> {
+    // Connect to the database
+    DB.connect::<Ws>("localhost:8000").await?;
+    // Sign in to the server
+    DB.signin(Root {
+        username: "root",
+        password: "root",
+    })
+    .await?;
+    // Select a namespace + database
+    DB.use_ns("dev").use_db("kagami").await?;
+
+    Ok(())
+}

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -1,0 +1,2 @@
+pub mod models;
+pub mod connection;

--- a/src-tauri/src/database/models/mod.rs
+++ b/src-tauri/src/database/models/mod.rs
@@ -1,0 +1,2 @@
+pub mod tasks;
+pub mod record;

--- a/src-tauri/src/database/models/record.rs
+++ b/src-tauri/src/database/models/record.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::RecordId;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RecordKeyModel {
+    pub id: RecordId,
+}

--- a/src-tauri/src/database/models/tasks.rs
+++ b/src-tauri/src/database/models/tasks.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::RecordId;
+
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Task {
+    pub id: RecordId,
+    pub name: String,
+    pub task: String,
+    pub checked: bool,
+    pub order: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TaskCreate {
+    pub name: String,
+    pub task: String,
+    pub checked: bool,
+    pub order: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckState {
+    pub checked: bool,
+}

--- a/src-tauri/src/features/mod.rs
+++ b/src-tauri/src/features/mod.rs
@@ -1,0 +1,1 @@
+pub mod tasks;

--- a/src-tauri/src/features/tasks/mod.rs
+++ b/src-tauri/src/features/tasks/mod.rs
@@ -1,0 +1,1 @@
+pub mod task_ctrl;

--- a/src-tauri/src/features/tasks/task_ctrl.rs
+++ b/src-tauri/src/features/tasks/task_ctrl.rs
@@ -1,0 +1,42 @@
+use surrealdb::opt::Resource;
+
+use crate::database::connection::surreal::DB;
+use crate::database::models::record::RecordKeyModel;
+use crate::database::models::tasks::{CheckState, Task, TaskCreate};
+
+// Crud methods for task
+// Create task
+pub async fn create_new_task(task: TaskCreate ) -> surrealdb::Result<()> {
+    dbg!(&task);
+    let record: Option<RecordKeyModel> = DB
+    .create("tasks")
+    .content(task).await?;
+    dbg!(record);
+    Ok(())
+}
+
+// Toggle Checked
+pub async fn toggle_checked(task_id: &str) -> surrealdb::Result<()> {
+    let task_item: Option<Task> = DB.select(("tasks", task_id)).await?;
+    let _update = DB
+        .update(Resource::from(("tasks", &task_id.to_string())))
+        .merge(CheckState {
+            checked: !(task_item.unwrap().checked),
+        })
+        .await?;
+    Ok(())
+}
+
+// Delete Task
+pub async fn remove_task(task_id: &str) -> surrealdb::Result<()> {
+    let _remove: Option<RecordKeyModel> = DB
+        .delete(("tasks", &task_id.to_string()))
+        .await?;
+    Ok(())
+}
+
+// List all tasks
+pub async fn get_tasks() -> surrealdb::Result<Vec<Task>> {
+    let tasks: Vec<Task> = DB.select("tasks").await?;
+    Ok(tasks)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,60 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use features::tasks::task_ctrl::{create_new_task, get_tasks, remove_task, toggle_checked};
+use database::models::tasks::{Task, TaskCreate};
+
+pub mod features;
+pub mod database;
+
+// use crate::db::models::Task;
+
+// // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("ello mate!, {}! You've been greeted from Rust!", name)
+}
+
+//Create a task in database
+#[tauri::command]
+async fn save_task(task: TaskCreate) -> surrealdb::Result<()> {
+    create_new_task(task).await?;
+    Ok(())
+}
+
+//Create a task in database
+#[tauri::command]
+async fn list_tasks() -> surrealdb::Result<Vec<Task>> {
+    let tasks: Vec<Task> = get_tasks().await?;
+    Ok(tasks)
+}
+
+//Create a task in database
+#[tauri::command]
+async fn update_check_state(task: &str) -> surrealdb::Result<Vec<Task>> {
+    dbg!(task);
+    let _update = toggle_checked(task).await?;
+    let tasks: Vec<Task> = get_tasks().await?;
+    Ok(tasks)
+}
+
+//Create a task in database
+#[tauri::command]
+async fn remove_selected_task(task: &str) -> surrealdb::Result<Vec<Task>> {
+    dbg!(task);
+    let _remove = remove_task(task).await?;
+    let tasks: Vec<Task> = get_tasks().await?;
+    Ok(tasks)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            save_task,
+            list_tasks,
+            update_check_state,
+            remove_selected_task
+        ])
         .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .expect("error while running tauri application")
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,13 @@
+// #![allow(unused)]
+
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-fn main() {
-    kagami_lib::run()
+use kagami_lib::database::connection::surreal::database_connection;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    database_connection().await?;
+    kagami_lib::run();
+    Ok(())
 }

--- a/src/blocks/todo/todo-c.ts
+++ b/src/blocks/todo/todo-c.ts
@@ -12,7 +12,7 @@ const useTodoController = () => {
 
   function newTask(title: string): Task {
     return {
-      task: `${Math.abs(Math.random() * 9999999999)}`,
+      task: `${Math.floor(Math.random() * 9999999999)}`,
       order: tasks.length,
       name: title,
       checked: false,

--- a/src/blocks/todo/todo-m.ts
+++ b/src/blocks/todo/todo-m.ts
@@ -7,7 +7,7 @@ export type Task = {
 };
 
 
-type Record = {
+export type Record = {
   id: {
     String: string
   },

--- a/src/blocks/todo/todo-m.ts
+++ b/src/blocks/todo/todo-m.ts
@@ -1,6 +1,15 @@
 export type Task = {
+  id?: Record;
   task: string;
   order: number;
   name: string;
   checked: boolean;
 };
+
+
+type Record = {
+  id: {
+    String: string
+  },
+  tb: string
+}


### PR DESCRIPTION
Implement persistent storage support for SurrealDB by adding database connection setup, CRUD methods for tasks, and necessary Tauri commands. 

Changes include:
- Added id field to Task type and created Record type with id and tb fields
- Implemented database connection setup and CRUD methods for tasks in `src-tauri/src/database/connection/surreal.rs` and `src-tauri/src/features/tasks/task_ctrl.rs`
- Modified `src-tauri/src/lib.rs` to include new Tauri commands for tasks handling